### PR TITLE
Add hide-units and hide-positive-number-sign options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The plugin could be customized with:
 * `set-option -g @tmux-weather-location "Tomsk"` - Set up your location, by default you will get the weather for your current location based on your IP address.
 * `set-option -g @tmux-weather-format "%c+%t+%w"` - Set up a representation, by default it is 1, for more options go to [https://github.com/chubin/wttr.in#one-line-output](https://github.com/chubin/wttr.in#one-line-output)
 * `set-option -g @tmux-weather-units" "m"` - Set up weather units (u - for USCS, m - for metric system), by default used metric units.
+* `set-option -g @tmux-weather-hide-units" "true"` - Hide the units (°C or °F)
+* `set-option -g @tmux-weather-hide-positive-number-sign" "true"` - Hide the + sign in front of positive temperatures (`+19°C -> 19°C`)
 
 ## Other plugins
 * [tmux-network-bandwidth](https://github.com/xamut/tmux-network-bandwidth)

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -1,22 +1,18 @@
 #!/usr/bin/env bash
 
-PATH="/usr/local/bin:$PATH:/usr/sbin"
-
 get_tmux_option() {
   local option_name="$1"
   local default_value="$2"
-  local option_value=$(tmux show-option -gqv $option_name)
+  local option_value
 
-  if [ -z "$option_value" ]; then
-    echo -n $default_value
-  else
-    echo -n $option_value
-  fi
+  option_value=$(tmux show-option -gqv "$option_name")
+
+  echo -n "${option_value:-${default_value}}"
 }
 
 set_tmux_option() {
   local option_name="$1"
   local option_value="$2"
-  $(tmux set-option -gq $option_name "$option_value")
+  tmux set-option -gq "$option_name" "$option_value"
 }
 

--- a/tmux-weather.tmux
+++ b/tmux-weather.tmux
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-source "$CURRENT_DIR/scripts/helpers.sh"
+
+source "${CURRENT_DIR}/scripts/helpers.sh"
 
 replace_placeholder_in_status_line() {
   local placeholder="\#{$1}"
   local script="#($2)"
-  local status_line_side=$3
-  local old_status_line=$(get_tmux_option $status_line_side)
-  local new_status_line=${old_status_line/$placeholder/$script}
+  local status_line_side=status-${3:-right}
+  local old_status_line
+  local new_status_line
 
-  $(set_tmux_option $status_line_side "$new_status_line")
+  old_status_line="$(get_tmux_option "$status_line_side")"
+  new_status_line=${old_status_line/$placeholder/$script}
+
+  set_tmux_option "$status_line_side" "$new_status_line"
 }
 
 main() {
   local weather="$CURRENT_DIR/scripts/weather.sh"
-  replace_placeholder_in_status_line "weather" "$weather" "status-right"
+  replace_placeholder_in_status_line "weather" "$weather"
 }
 
 main

--- a/tmux-weather.tmux
+++ b/tmux-weather.tmux
@@ -19,7 +19,8 @@ replace_placeholder_in_status_line() {
 
 main() {
   local weather="$CURRENT_DIR/scripts/weather.sh"
-  replace_placeholder_in_status_line "weather" "$weather"
+  replace_placeholder_in_status_line "weather" "$weather" right
+  replace_placeholder_in_status_line "weather" "$weather" left
 }
 
 main


### PR DESCRIPTION
Moien,

I want to customize the output format a little bit further.

This PR introduces 2 new config options:

- `@tmux-weather-hide-units`: Hides the units (`+19°C` -> `+19`)
- `@tmux-weather-hide-positive-number-sign`: Hides the `+` sign in front of positive temps (`+19°C` -> `19°C`)

As a bonus I ran shellcheck on the existing codebase and implemented the recommendations.