### PR TITLE
Always update if previous weather value is empty

### DIFF
--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -21,11 +21,7 @@ main() {
   local previous_update=$(get_tmux_option "@weather-previous-update-time")
   local delta=$((current_time - previous_update))
 
-  if [ -z "$previous_update" ]; then
-    echo -n "Please wait..."
-    $(set_tmux_option "@weather-previous-update-time" "$(($current_time - $update_interval))")
-    return 0
-  elif [ $delta -ge $update_interval ]; then
+  if [ -z "$previous_update" ] || [ $delta -ge $update_interval ]; then
     local value=$(get_weather)
     if [ "$?" -eq 0 ]; then
       $(set_tmux_option "@weather-previous-update-time" "$current_time")

--- a/scripts/weather.sh
+++ b/scripts/weather.sh
@@ -20,8 +20,11 @@ main() {
   local current_time=$(date "+%s")
   local previous_update=$(get_tmux_option "@weather-previous-update-time")
   local delta=$((current_time - previous_update))
+  local previous_value=$(get_tmux_option "@weather-previous-value")
 
-  if [ -z "$previous_update" ] || [ $delta -ge $update_interval ]; then
+  if [ -z "$previous_value" ] || [ -z "$previous_update" ] \
+      || [ $delta -ge $update_interval ]; then
+
     local value=$(get_weather)
     if [ "$?" -eq 0 ]; then
       $(set_tmux_option "@weather-previous-update-time" "$current_time")


### PR DESCRIPTION
The weather occasionally stops being displayed because the previous value is empty but the next update time has not yet arrived. Therefore, if the weather value is empty, update immediately.