### PR TITLE
Correct example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ The plugin could be customized with:
 * `set-option -g @tmux-weather-interval 15` - Set up the update interval in minutes, by default it is 15 minutes.
 * `set-option -g @tmux-weather-location "Tomsk"` - Set up your location, by default you will get the weather for your current location based on your IP address.
 * `set-option -g @tmux-weather-format "%c+%t+%w"` - Set up a representation, by default it is 1, for more options go to [https://github.com/chubin/wttr.in#one-line-output](https://github.com/chubin/wttr.in#one-line-output)
-* `set-option -g @tmux-weather-units" "m"` - Set up weather units (u - for USCS, m - for metric system), by default used metric units.
+* `set-option -g @tmux-weather-units "m"` - Set up weather units (u - for USCS, m - for metric system), by default used metric units.
 
 ## Other plugins
 * [tmux-network-bandwidth](https://github.com/xamut/tmux-network-bandwidth)


### PR DESCRIPTION
Remove the extra " from the documentation for the `tmux-weather-units` example.